### PR TITLE
chore: eslint + prettier linebreak-style 옵션 변경

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    'linebreak-style': ['error', 'auto'],
+    'linebreak-style': 'off',
   },
 };

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm run format
 
       - name: Run unit tests
-        run: npm run test:cov
+        run: npm run test:cov -- --passWithNoTests

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});


### PR DESCRIPTION
### 제목  
[PR] ESLint + Prettier linebreak-style 옵션 변경

### 설명  
- 변경 내용 요약:  
  1. eslint의 linebreak-style을 비활성화
  2. prettierrc에서 설정
  3. yml 파일의 테스트 스크립트에 테스트 파일이 없을 때도 통과하도록 변경

### 작업 우선순위  
- <낮음>
