### PR TITLE
[PR] 채팅방 소켓 연결 해제 로직 수정

### DIFF
--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { FindByCursorDto } from './dtos/find-by-cursor.dto';
 import { HttpContent } from '../../common/interfaces/http-response.interface';
-import { RoomResponse } from './interfaces/room-response.interface';
+import { RoomInfo } from './interfaces/room-info.interface';
 import { ChatService } from './chat.service';
 import { FindByOffsetDto } from './dtos/find-by-offset.dto';
 import { UserWithNickname } from './interfaces/user-with-nickname.interface';
@@ -13,7 +13,7 @@ export class ChatController {
   @Get('rooms/offset')
   async getChatRoomsByOffset(
     @Query() findRoomDto: FindByOffsetDto,
-  ): Promise<HttpContent<RoomResponse[]>> {
+  ): Promise<HttpContent<RoomInfo[]>> {
     const { data, pagination } =
       await this.chatService.findRoomsByOffset(findRoomDto);
 
@@ -27,7 +27,7 @@ export class ChatController {
   @Get('rooms/cursor')
   async getChatRoomsByCursor(
     @Query() findRoomDto: FindByCursorDto,
-  ): Promise<HttpContent<RoomResponse[]>> {
+  ): Promise<HttpContent<RoomInfo[]>> {
     const { data, pagination } =
       await this.chatService.findRoomsByCursor(findRoomDto);
 
@@ -41,7 +41,7 @@ export class ChatController {
   @Get('rooms/:id')
   async getChatRoomById(
     @Param('id') id: string,
-  ): Promise<HttpContent<RoomResponse>> {
+  ): Promise<HttpContent<RoomInfo>> {
     const roomId = parseInt(id);
     const room = await this.chatService.findRoomById(roomId);
 

--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -21,7 +21,8 @@ import { WsResponseInterceptor } from 'src/common/interceptors/ws-response.inter
 import { LoggingInterceptor } from 'src/common/interceptors/logging.interceptor';
 import { WsContent } from 'src/common/interfaces/ws-response.interface';
 import { SendMessageDto } from './dtos/send-message.dto';
-import { RoomIdResponse } from './interfaces/room-id-response.interface';
+import { CreateRoomResponse } from './interfaces/create-room-response.interface';
+import { UserWithNickname } from './interfaces/user-with-nickname.interface';
 
 @WebSocketGateway({ namespace: 'chat' })
 @UseInterceptors(WsResponseInterceptor, LoggingInterceptor)
@@ -75,16 +76,22 @@ export class ChatGateway {
   async handleCreateRoom(
     @ConnectedSocket() client: Socket,
     @MessageBody() createRoomDto: CreateRoomDto,
-  ): Promise<WsContent<RoomIdResponse>> {
+  ): Promise<WsContent<CreateRoomResponse>> {
     const user = client.data.user;
-    const room = await this.chatService.createChatRoom(user.id, createRoomDto);
+    const roomId = await this.chatService.createChatRoom(
+      user.id,
+      createRoomDto,
+    );
+    const participant = await this.chatService.findParticipantById(user.id);
 
-    client.join(room.toString());
+    client.join(roomId.toString());
 
     return {
       event: 'room_created',
       data: {
-        roomId: room,
+        roomId,
+        userId: participant.id,
+        nickname: participant.nickname,
       },
     };
   }
@@ -95,7 +102,7 @@ export class ChatGateway {
   async handleJoinRoom(
     @ConnectedSocket() client: Socket,
     @MessageBody() joinRoomDto: JoinRoomDto,
-  ): Promise<WsContent<null>> {
+  ): Promise<WsContent<UserWithNickname>> {
     const user = client.data.user;
     const roomId = joinRoomDto.roomId;
     await this.chatService.createParticipant(user.id, roomId);
@@ -109,7 +116,7 @@ export class ChatGateway {
 
     return {
       event: 'room_joined',
-      data: null,
+      data: participant,
     };
   }
 

--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -55,14 +55,19 @@ export class ChatGateway {
   }
 
   async handleDisconnect(client: Socket) {
-    const clientId = client.id;
-    const user = client.data.user;
-    if (user) {
-      await this.handleLeaveRoom(client);
+    try {
+      const clientId = client.id;
+      const user = client.data.user;
+      const roomId = await this.chatService.findRoomByUserId(user.id);
+      if (roomId) {
+        await this.handleLeaveRoom(client);
+      }
+      this.logger.log(
+        `Socket client(${clientId}) has disconnected from the server.`,
+      );
+    } catch (error) {
+      this.logger.error(`${client.id} - ${error.stack}`);
     }
-    this.logger.log(
-      `Socket client(${clientId}) has disconnected from the server.`,
-    );
   }
 
   @SubscribeMessage('create_room')

--- a/src/modules/chat/chat.gateway.ts
+++ b/src/modules/chat/chat.gateway.ts
@@ -58,8 +58,7 @@ export class ChatGateway {
     try {
       const clientId = client.id;
       const user = client.data.user;
-      const roomId = await this.chatService.findRoomByUserId(user.id);
-      if (roomId) {
+      if (user) {
         await this.handleLeaveRoom(client);
       }
       this.logger.log(

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -20,10 +20,10 @@ import { UserService } from '../user/user.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { FindByCursorDto } from './dtos/find-by-cursor.dto';
 import {
-  RoomResponse,
-  RoomResponseByCursor,
-  RoomResponseByOffset,
-} from './interfaces/room-response.interface';
+  RoomInfo,
+  RoomInfoByCursor,
+  RoomInfoByOffset,
+} from './interfaces/room-info.interface';
 import { FindByOffsetDto } from './dtos/find-by-offset.dto';
 import {
   CursorPagination,
@@ -108,6 +108,7 @@ export class ChatService {
 
     const room = await this.prisma.chatRoom.create({
       data: newRoom,
+      select: { id: true },
     });
 
     return room.id;
@@ -253,7 +254,7 @@ export class ChatService {
 
   async findRoomsByOffset(
     findRoomDto: FindByOffsetDto,
-  ): Promise<RoomResponseByOffset> {
+  ): Promise<RoomInfoByOffset> {
     const {
       sort,
       alcoholCategory,
@@ -313,7 +314,7 @@ export class ChatService {
 
   async findRoomsByCursor(
     findRoomDto: FindByCursorDto,
-  ): Promise<RoomResponseByCursor> {
+  ): Promise<RoomInfoByCursor> {
     const {
       sort,
       alcoholCategory,
@@ -451,7 +452,7 @@ export class ChatService {
     return cookies['access_token'];
   }
 
-  async findRoomById(roomId: number): Promise<RoomResponse> {
+  async findRoomById(roomId: number): Promise<RoomInfo> {
     if (!roomId) {
       throw new BadRequestException('유효하지 않은 채팅방 ID 값입니다.');
     }

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -137,11 +137,11 @@ export class ChatService {
     });
 
     if (!participant) {
-      throw new NotFoundException('참가한 채팅방이 없습니다.');
+      return;
     }
 
     const roomId = participant.roomId;
-    let hostCandidate;
+    let hostCandidate: { userId: number } | undefined;
     if (participant.isHost) {
       hostCandidate = await this.prisma.chatParticipant.findFirst({
         where: { roomId, userId: { not: userId } },

--- a/src/modules/chat/interfaces/create-room-response.interface.ts
+++ b/src/modules/chat/interfaces/create-room-response.interface.ts
@@ -1,0 +1,5 @@
+export interface CreateRoomResponse {
+  roomId: number;
+  userId: number;
+  nickname: string;
+}

--- a/src/modules/chat/interfaces/room-id-response.interface.ts
+++ b/src/modules/chat/interfaces/room-id-response.interface.ts
@@ -1,3 +1,0 @@
-export interface RoomIdResponse {
-  roomId: number;
-}

--- a/src/modules/chat/interfaces/room-info.interface.ts
+++ b/src/modules/chat/interfaces/room-info.interface.ts
@@ -3,7 +3,7 @@ import {
   OffsetPagination,
 } from '../../../common/interfaces/pagination.interface';
 
-export interface RoomResponse {
+export interface RoomInfo {
   id: number;
   name: string;
   description?: string;
@@ -12,12 +12,12 @@ export interface RoomResponse {
   participants: number;
 }
 
-export interface RoomResponseByOffset {
-  data: RoomResponse[];
+export interface RoomInfoByOffset {
+  data: RoomInfo[];
   pagination: OffsetPagination;
 }
 
-export interface RoomResponseByCursor {
-  data: RoomResponse[];
+export interface RoomInfoByCursor {
+  data: RoomInfo[];
   pagination: CursorPagination;
 }


### PR DESCRIPTION
### 제목  
[PR] 채팅방 소켓 연결 해제 로직 수정

### 설명    
- 변경 내용 요약:  
  1. 웹소켓 필터가 handleDisconnect에서 발생한 에러는 잡지 않아서 catch문 추가
  2. 채팅방 퇴장시 참가한 방이 없으면 에러 대신 정상 응답, 다른 사용자에겐 알림이 가지 않도록 수정

### 작업 우선순위  
- <낮음>

---
